### PR TITLE
fix: ship /api/v2/ on R2 + fix dead /requests link

### DIFF
--- a/scripts/upload-to-r2.sh
+++ b/scripts/upload-to-r2.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Upload public/static/ to Cloudflare R2 using AWS CLI (S3-compatible API)
+# Upload public/static/ and public/api/ to Cloudflare R2 using AWS CLI
+# (S3-compatible API).
 #
 # Prerequisites:
 #   1. Create an R2 API token in Cloudflare dashboard (R2 > Manage R2 API Tokens)
@@ -13,12 +14,6 @@ set -euo pipefail
 
 R2_ENDPOINT="https://3bd272de7abb5a9f328fbfa9afafd2a3.r2.cloudflarestorage.com"
 R2_BUCKET="qualibact"
-SOURCE_DIR="public/static"
-
-if [ ! -d "$SOURCE_DIR" ]; then
-  echo "Error: $SOURCE_DIR directory not found. Run from project root."
-  exit 1
-fi
 
 if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
   echo "Error: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set."
@@ -26,26 +21,41 @@ if [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
   exit 1
 fi
 
-echo "Uploading $SOURCE_DIR to R2 bucket: $R2_BUCKET"
+# Two prefixes get uploaded:
+#   public/static/ -> s3://qualibact/static/   (bulk plots, atb tier CSVs,
+#                                              refseq archives, assembly stats)
+#   public/api/    -> s3://qualibact/api/      (the v2 threshold API blobs
+#                                              referenced via staticUrl())
+sync_dir() {
+  local src="$1"
+  local prefix="$2"
+  if [ ! -d "$src" ]; then
+    echo "Warning: $src not found, skipping."
+    return 0
+  fi
+  echo "Uploading $src -> s3://$R2_BUCKET/$prefix"
+  aws s3 sync "$src" "s3://$R2_BUCKET/$prefix" \
+    --endpoint-url "$R2_ENDPOINT" \
+    --region auto \
+    --delete \
+    --no-progress \
+    --exclude "*.DS_Store"
+  echo ""
+}
+
 echo "Endpoint: $R2_ENDPOINT"
 echo ""
 
-# Sync with appropriate content types
-aws s3 sync "$SOURCE_DIR" "s3://$R2_BUCKET/static" \
-  --endpoint-url "$R2_ENDPOINT" \
-  --region auto \
-  --delete \
-  --no-progress \
-  --exclude "*.DS_Store"
+sync_dir "public/static" "static"
+sync_dir "public/api" "api"
 
-echo ""
 echo "Upload complete!"
-echo "Files are at: s3://$R2_BUCKET/static/"
+echo "Files are at: s3://$R2_BUCKET/static/ and s3://$R2_BUCKET/api/"
 echo ""
-echo "Next steps:"
-echo "  1. Enable public access on the R2 bucket in Cloudflare dashboard"
-echo "  2. Set NEXT_PUBLIC_STATIC_URL in Vercel to your R2 public URL"
-echo "  3. Configure CORS on the R2 bucket (Settings > CORS Policy):"
+echo "Reminders:"
+echo "  1. R2 bucket public access must be enabled (Cloudflare Dashboard > R2)."
+echo "  2. NEXT_PUBLIC_STATIC_URL=https://static.qualibact.org points the site at it."
+echo "  3. CORS on the bucket (Settings > CORS Policy):"
 echo "       Allowed Origins: https://qualibact.org"
 echo "       Allowed Methods: GET, HEAD"
 echo "       Allowed Headers: *"

--- a/src/app/contributors/page.tsx
+++ b/src/app/contributors/page.tsx
@@ -84,7 +84,7 @@ export default function ContributorsPage() {
             Are you missing from this list? Contributions land via the
             expert-feedback survey or direct correspondence — see the{' '}
             <Link
-              href="/requests"
+              href="/organism-requests/"
               className="underline underline-offset-2 hover:text-neutral-800 dark:hover:text-neutral-200"
             >
               requests page

--- a/src/components/ThresholdRationaleTable.tsx
+++ b/src/components/ThresholdRationaleTable.tsx
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
+import { staticUrl } from '@/lib/static-url';
 
 interface OverrideEntry {
   species: string;
@@ -64,7 +65,7 @@ export default function ThresholdRationaleTable() {
       <p className="text-sm text-neutral-600 dark:text-neutral-400">
         Source file:{' '}
         <a
-          href="/api/v2/threshold-rationale.yml"
+          href={staticUrl('/api/v2/threshold-rationale.yml')}
           className="underline"
           download="threshold-rationale.yml"
         >


### PR DESCRIPTION
1. Extend upload-to-r2.sh to sync public/api/ -> s3://qualibact/api/ alongside the existing public/static/ -> s3://qualibact/static/ sync. The /api/v2/ blobs are referenced via staticUrl() which resolves to static.qualibact.org; without this upload they 404'd against R2.

2. Switch ThresholdRationaleTable's source-file link from a relative /api/v2/ path to staticUrl('/api/v2/threshold-rationale.yml') so the download button goes to R2 like the rest of the /api/v2/ links.

3. /requests -> /organism-requests/ in contributors/page.tsx (the actual route name on the site).